### PR TITLE
RestX & Swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ The Fink cutout API is a Flask application to access cutouts from the Fink datal
 
 ## Documentation
 
-The user documentation can be found at this [link](https://fink-broker.readthedocs.io/en/latest/services/search/getting_started/#quick-start-api). Documentation for developpers and maintainers can be found on [GitLab](https://gitlab.in2p3.fr/fink/rubin-performance-check/-/blob/main/portal/README.md?ref_type=heads) (auth required).
+There are several forms of documentation, depending on what you are looking for: 
+
+- Tutorials/How-to guides: [Fink user manual](https://fink-broker.readthedocs.io/en/latest/services/search/getting_started/#quick-start-api)
+- API Reference guide: [https://api.fink-portal.org](https://api.fink-portal.org)
+- Notes for developpers and maintainers (auth required): [GitLab](https://gitlab.in2p3.fr/fink/rubin-performance-check/-/blob/main/portal/README.md?ref_type=heads)
 
 ## Requirements and installation
 
@@ -24,7 +28,7 @@ The input parameters can be found in [config.yml](config.yml). Make sure that th
 
 ### Debug
 
-After starting [fink-cutout-api](https://github.com/astrolabsoftware/fink-cutout-api), you can simply test the API using:
+After starting the Fink Java Gateway and [fink-cutout-api](https://github.com/astrolabsoftware/fink-cutout-api) services, you can simply launch the API in debug mode using:
 
 ```bash
 python app.py
@@ -32,7 +36,7 @@ python app.py
 
 ### Production
 
-The application is simply managed by `gunicorn` and `systemd` (see [install](install/README.md)), and you can simply manage it using:
+The application is simply managed by `gunicorn` and `systemd` (see [install](install/README.md)), and you can manage it using:
 
 ```bash
 # start the application

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The Java Gateway enables the Flask application to communicate with a JVM using [
 
 The Fink cutout API is a Flask application to access cutouts from the Fink datalake. We only store cutout metadata in HBase, and this API retrieves the data from the raw parquet files stored on HDFS.
 
+_From 2019 to 2024, the development of this API was done in [fink-science-portal](https://github.com/astrolabsoftware/fink-science-portal). Check this repository for older issues and PR._
+
 ## Documentation
 
 There are several forms of documentation, depending on what you are looking for: 

--- a/apps/routes/cutouts/api.py
+++ b/apps/routes/cutouts/api.py
@@ -12,93 +12,89 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from flask import Blueprint, Response, jsonify, request
+from flask import Response, request
+from flask_restx import Namespace, Resource, fields
+
 from apps.utils.utils import check_args
 
 from apps.routes.cutouts.utils import format_and_send_cutout
 
-bp = Blueprint("cutouts", __name__)
+ns = Namespace("api/v1/cutouts", "Get cutout data based on ZTF ID")
 
-
-# Enable CORS for this blueprint
-@bp.after_request
-def after_request(response):
-    response.headers.add("Access-Control-Allow-Origin", "*")
-    response.headers.add("Access-Control-Allow-Headers", "Content-Type,Authorization")
-    response.headers.add("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE,OPTIONS")
-    return response
-
-
-ARGS = [
+ARGS = ns.model(
+    "cutouts",
     {
-        "name": "objectId",
-        "required": True,
-        "description": "ZTF Object ID",
+        "objectId": fields.String(
+            description="ZTF Object ID",
+            example="ZTF24abuunge",
+            required=True,
+        ),
+        "kind": fields.String(
+            description="Science, Template, or Difference. For output-format=array, you can also specify `kind: All` to get the 3 cutouts.",
+            example="Science",
+            required=True,
+        ),
+        "output-format": fields.String(
+            description="PNG[default], FITS, array", example="array", required=False
+        ),
+        "candid": fields.Integer(
+            description="Candidate ID of the alert belonging to the object with `objectId`. If not filled, the cutouts of the latest alert is returned",
+            example=2890466950515015016,
+            required=False,
+        ),
+        "stretch": fields.String(
+            description="Stretch function to be applied. Available: sigmoid[default], linear, sqrt, power, log.",
+            example="sigmoid",
+            required=False,
+        ),
+        "colormap": fields.String(
+            description="Valid matplotlib colormap name (see matplotlib.cm). Default is grayscale.",
+            example="Blues",
+            required=False,
+        ),
+        "pmin": fields.Float(
+            description="The percentile value used to determine the pixel value of minimum cut level. Default is 0.5. No effect for sigmoid.",
+            example=0.5,
+            required=False,
+        ),
+        "pmax": fields.Float(
+            description="The percentile value used to determine the pixel value of maximum cut level. Default is 99.5. No effect for sigmoid.",
+            example=99.5,
+            required=False,
+        ),
+        "convolution_kernel": fields.String(
+            description="Convolve the image with a kernel (gauss or box). If not specified, no kernel is applied.",
+            example="gauss",
+            required=False,
+        ),
     },
-    {
-        "name": "kind",
-        "required": True,
-        "description": "Science, Template, or Difference. For output-format=array, you can also specify `kind: All` to get the 3 cutouts.",
-    },
-    {
-        "name": "output-format",
-        "required": False,
-        "description": "PNG[default], FITS, array",
-    },
-    {
-        "name": "candid",
-        "required": False,
-        "description": "Candidate ID of the alert belonging to the object with `objectId`. If not filled, the cutouts of the latest alert is returned",
-    },
-    {
-        "name": "stretch",
-        "required": False,
-        "description": "Stretch function to be applied. Available: sigmoid[default], linear, sqrt, power, log.",
-    },
-    {
-        "name": "colormap",
-        "required": False,
-        "description": "Valid matplotlib colormap name (see matplotlib.cm). Default is grayscale.",
-    },
-    {
-        "name": "pmin",
-        "required": False,
-        "description": "The percentile value used to determine the pixel value of minimum cut level. Default is 0.5. No effect for sigmoid.",
-    },
-    {
-        "name": "pmax",
-        "required": False,
-        "description": "The percentile value used to determine the pixel value of maximum cut level. Default is 99.5. No effect for sigmoid.",
-    },
-    {
-        "name": "convolution_kernel",
-        "required": False,
-        "description": "Convolve the image with a kernel (gauss or box). Default is None (not specified).",
-    },
-]
+)
 
 
-@bp.route("/api/v1/cutouts", methods=["GET"])
-def return_cutouts_arguments():
-    """Obtain information about cutouts"""
-    if len(request.args) > 0:
-        # POST from query URL
-        return return_cutouts(payload=request.args)
-    else:
-        return jsonify({"args": ARGS})
+@ns.route("/")
+@ns.doc(params={dic["name"]: dic["description"] for dic in ARGS})
+class Cutouts(Resource):
+    def get(self):
+        """Retrieve cutout data from the Fink/ZTF datalake"""
+        self.payload = request.args
+        if len(self.payload) > 0:
+            # POST from query URL
+            return self.post()
+        else:
+            return Response(ARGS.description, 200)
 
+    def post(self):
+        """Retrieve cutout data from the Fink/ZTF datalake"""
+        # get payload from the JSON
+        payload = request.args
 
-@bp.route("/api/v1/cutouts", methods=["POST"])
-def return_cutouts(payload=None):
-    """Retrieve object data"""
-    # get payload from the JSON
-    if payload is None:
-        payload = request.json
+        if payload is None:
+            payload = request.json
 
-    rep = check_args(ARGS, payload)
-    if rep["status"] != "ok":
-        return Response(str(rep), 400)
+        rep = check_args(ARGS, payload)
+        if rep["status"] != "ok":
+            return Response(str(rep), 400)
 
-    assert payload["kind"] in ["Science", "Template", "Difference", "All"]
+        assert payload["kind"] in ["Science", "Template", "Difference", "All"]
 
-    return format_and_send_cutout(payload)
+        return format_and_send_cutout(payload)

--- a/apps/routes/cutouts/api.py
+++ b/apps/routes/cutouts/api.py
@@ -76,8 +76,8 @@ ARGS = ns.model(
 class Cutouts(Resource):
     def get(self):
         """Retrieve cutout data from the Fink/ZTF datalake"""
-        self.payload = request.args
-        if len(self.payload) > 0:
+        payload = request.args
+        if len(payload) > 0:
             # POST from query URL
             return self.post()
         else:
@@ -85,10 +85,11 @@ class Cutouts(Resource):
 
     def post(self):
         """Retrieve cutout data from the Fink/ZTF datalake"""
-        # get payload from the JSON
+        # get payload from the query URL
         payload = request.args
 
-        if payload is None:
+        if payload is None or len(payload) == 0:
+            # if no payload, try the JSON blob
             payload = request.json
 
         rep = check_args(ARGS, payload)

--- a/apps/routes/cutouts/api.py
+++ b/apps/routes/cutouts/api.py
@@ -72,7 +72,7 @@ ARGS = ns.model(
 
 
 @ns.route("/")
-@ns.doc(params={dic["name"]: dic["description"] for dic in ARGS})
+@ns.doc(params={k: ARGS[k].description for k in ARGS})
 class Cutouts(Resource):
     def get(self):
         """Retrieve cutout data from the Fink/ZTF datalake"""

--- a/apps/routes/cutouts/api.py
+++ b/apps/routes/cutouts/api.py
@@ -83,6 +83,7 @@ class Cutouts(Resource):
         else:
             return Response(ARGS.description, 200)
 
+    @ns.expect(ARGS, location="json", as_dict=True)
     def post(self):
         """Retrieve cutout data from the Fink/ZTF datalake"""
         # get payload from the query URL

--- a/apps/routes/cutouts/utils.py
+++ b/apps/routes/cutouts/utils.py
@@ -91,6 +91,7 @@ def format_and_send_cutout(payload: dict):
         group_alerts=False,
         truncated=True,
         extract_color=False,
+        escape_slash=True,
     )
 
     json_payload = {}

--- a/apps/routes/objects/api.py
+++ b/apps/routes/objects/api.py
@@ -71,6 +71,7 @@ class Objects(Resource):
         else:
             return Response(ARGS.description, 200)
 
+    @ns.expect(ARGS, location="json", as_dict=True)
     def post(self):
         """Retrieve object data from the Fink/ZTF database"""
         # get payload from the query URL

--- a/apps/routes/objects/api.py
+++ b/apps/routes/objects/api.py
@@ -64,8 +64,8 @@ ARGS = ns.model(
 class Objects(Resource):
     def get(self):
         """Retrieve object data from the Fink/ZTF database"""
-        self.payload = request.args
-        if len(self.payload) > 0:
+        payload = request.args
+        if len(payload) > 0:
             # POST from query URL
             return self.post()
         else:
@@ -73,10 +73,11 @@ class Objects(Resource):
 
     def post(self):
         """Retrieve object data from the Fink/ZTF database"""
-        # get payload from the JSON
+        # get payload from the query URL
         payload = request.args
 
-        if payload is None:
+        if payload is None or len(payload) == 0:
+            # if no payload, try the JSON blob
             payload = request.json
 
         rep = check_args(ARGS, payload)

--- a/apps/routes/objects/api.py
+++ b/apps/routes/objects/api.py
@@ -12,84 +12,82 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from flask import Blueprint, Response, jsonify, request
+from flask import Response, request
+from flask_restx import Namespace, Resource, fields
+
 from apps.utils.utils import check_args
 from apps.utils.utils import send_tabular_data
 
 from apps.routes.objects.utils import extract_object_data
 
-bp = Blueprint("objects", __name__)
+ns = Namespace("api/v1/objects", "Get object data based on ZTF ID")
 
-
-# Enable CORS for this blueprint
-@bp.after_request
-def after_request(response):
-    response.headers.add("Access-Control-Allow-Origin", "*")
-    response.headers.add("Access-Control-Allow-Headers", "Content-Type,Authorization")
-    response.headers.add("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE,OPTIONS")
-    return response
-
-
-ARGS = [
+ARGS = ns.model(
+    "objects",
     {
-        "name": "objectId",
-        "required": True,
-        "description": 'single ZTF Object ID, or a comma-separated list of object names, e.g. "ZTF19acmdpyr,ZTF21aaxtctv"',
+        "objectId": fields.String(
+            description='single ZTF Object ID, or a comma-separated list of object names, e.g. "ZTF19acmdpyr,ZTF21aaxtctv"',
+            example="ZTF21abfmbix",
+            required=True,
+        ),
+        "withupperlim": fields.Boolean(
+            description="If True, retrieve also upper limit measurements, and bad quality measurements. Use the column `d:tag` in your results: valid, upperlim, badquality.",
+            example=True,
+            required=False,
+        ),
+        "withcutouts": fields.Boolean(
+            description="If True, retrieve also cutout data as 2D array. See also `cutout-kind`. More information on the original cutouts at https://irsa.ipac.caltech.edu/data/ZTF/docs/ztf_explanatory_supplement.pdf",
+            example=False,
+            required=False,
+        ),
+        "cutout-kind": fields.String(
+            description="`Science`, `Template`, or `Difference`. If not specified, returned all three.",
+            example="Science",
+            required=False,
+        ),
+        "columns": fields.String(
+            description="Comma-separated data columns to transfer, e.g. 'i:magpsf,i:jd'. If not specified, transfer all columns.",
+            example="i:magpsf,i:jd",
+            required=False,
+        ),
+        "output-format": fields.String(
+            description="Output format among json[default], csv, parquet, votable.",
+            example="json",
+            required=False,
+        ),
     },
-    {
-        "name": "withupperlim",
-        "required": False,
-        "description": "If True, retrieve also upper limit measurements, and bad quality measurements. Use the column `d:tag` in your results: valid, upperlim, badquality.",
-    },
-    {
-        "name": "withcutouts",
-        "required": False,
-        "description": "If True, retrieve also cutout data as 2D array. See also `cutout-kind`. More information on the original cutouts at https://irsa.ipac.caltech.edu/data/ZTF/docs/ztf_explanatory_supplement.pdf",
-    },
-    {
-        "name": "cutout-kind",
-        "required": False,
-        "description": "`Science`, `Template`, or `Difference`. If not specified, returned all three.",
-    },
-    {
-        "name": "columns",
-        "required": False,
-        "description": "Comma-separated data columns to transfer. Default is all columns.",
-    },
-    {
-        "name": "output-format",
-        "required": False,
-        "description": "Output format among json[default], csv, parquet, votable",
-    },
-]
+)
 
 
-@bp.route("/api/v1/objects", methods=["GET"])
-def return_object_arguments():
-    """Obtain information about retrieving object data"""
-    if len(request.args) > 0:
-        # POST from query URL
-        return return_object(payload=request.args)
-    else:
-        return jsonify({"args": ARGS})
+@ns.route("/")
+@ns.doc(params={dic["name"]: dic["description"] for dic in ARGS})
+class Objects(Resource):
+    def get(self):
+        """Retrieve object data from the Fink/ZTF database"""
+        self.payload = request.args
+        if len(self.payload) > 0:
+            # POST from query URL
+            return self.post()
+        else:
+            return Response(ARGS.description, 200)
 
+    def post(self):
+        """Retrieve object data from the Fink/ZTF database"""
+        # get payload from the JSON
+        payload = request.args
 
-@bp.route("/api/v1/objects", methods=["POST"])
-def return_object(payload=None):
-    """Retrieve object data from the Fink database"""
-    # get payload from the JSON
-    if payload is None:
-        payload = request.json
+        if payload is None:
+            payload = request.json
 
-    rep = check_args(ARGS, payload)
-    if rep["status"] != "ok":
-        return Response(str(rep), 400)
+        rep = check_args(ARGS, payload)
+        if rep["status"] != "ok":
+            return Response(str(rep), 400)
 
-    out = extract_object_data(payload)
+        out = extract_object_data(payload)
 
-    # Error propagation
-    if isinstance(out, Response):
-        return out
+        # Error propagation
+        if isinstance(out, Response):
+            return out
 
-    output_format = payload.get("output-format", "json")
-    return send_tabular_data(out, output_format)
+        output_format = payload.get("output-format", "json")
+        return send_tabular_data(out, output_format)

--- a/apps/routes/objects/api.py
+++ b/apps/routes/objects/api.py
@@ -32,7 +32,7 @@ ARGS = ns.model(
         ),
         "withupperlim": fields.Boolean(
             description="If True, retrieve also upper limit measurements, and bad quality measurements. Use the column `d:tag` in your results: valid, upperlim, badquality.",
-            example=True,
+            example=False,
             required=False,
         ),
         "withcutouts": fields.Boolean(
@@ -47,7 +47,7 @@ ARGS = ns.model(
         ),
         "columns": fields.String(
             description="Comma-separated data columns to transfer, e.g. 'i:magpsf,i:jd'. If not specified, transfer all columns.",
-            example="i:magpsf,i:jd",
+            example="i:jd,i:magpsf,i:fid",
             required=False,
         ),
         "output-format": fields.String(

--- a/apps/routes/objects/api.py
+++ b/apps/routes/objects/api.py
@@ -60,7 +60,7 @@ ARGS = ns.model(
 
 
 @ns.route("/")
-@ns.doc(params={dic["name"]: dic["description"] for dic in ARGS})
+@ns.doc(params={k: ARGS[k].description for k in ARGS})
 class Objects(Resource):
     def get(self):
         """Retrieve object data from the Fink/ZTF database"""

--- a/apps/routes/objects/test.py
+++ b/apps/routes/objects/test.py
@@ -146,7 +146,9 @@ def test_withcutouts_single_field() -> None:
     """
     pdf = get_an_object(oid=OID, withcutouts=True, cutout_kind="Science")
 
-    assert isinstance(pdf["b:cutoutScience_stampData"].to_numpy()[0], list)
+    cutout = pdf["b:cutoutScience_stampData"].to_numpy()[0]
+    assert isinstance(cutout, list), cutout
+    assert len(cutout) != 0, cutout
     assert "b:cutoutTemplate_stampData" not in pdf.columns
 
 

--- a/apps/utils/decoding.py
+++ b/apps/utils/decoding.py
@@ -47,13 +47,14 @@ def format_hbase_output(
     truncated: bool = False,
     extract_color: bool = True,
     with_constellation: bool = True,
+    escape_slash: bool = False,
 ):
     """ """
     if len(hbase_output) == 0:
         return pd.DataFrame({})
 
     # Construct the dataframe
-    pdfs = pd.DataFrame.from_dict(hbase_to_dict(hbase_output), orient="index")
+    pdfs = pd.DataFrame.from_dict(hbase_to_dict(hbase_output, escape_slash=escape_slash), orient="index")
 
     # Tracklet cell contains null if there is nothing
     # and so HBase won't transfer data -- ignoring the column
@@ -144,13 +145,15 @@ def format_hbase_output(
 
 
 @profile
-def hbase_to_dict(hbase_output):
+def hbase_to_dict(hbase_output, escape_slash=False):
     """Optimize hbase output TreeMap for faster conversion to DataFrame"""
     gateway = JavaGateway(auto_convert=True)
     JSONObject = gateway.jvm.org.json.JSONObject
 
     # We do bulk export to JSON on Java side to avoid overheads of iterative access
     # and then parse it back to Dict in Python
+    if escape_slash:
+        hbase_output = str(hbase_output)
     optimized = json.loads(JSONObject(str(hbase_output)).toString())
 
     return optimized

--- a/apps/utils/decoding.py
+++ b/apps/utils/decoding.py
@@ -54,7 +54,9 @@ def format_hbase_output(
         return pd.DataFrame({})
 
     # Construct the dataframe
-    pdfs = pd.DataFrame.from_dict(hbase_to_dict(hbase_output, escape_slash=escape_slash), orient="index")
+    pdfs = pd.DataFrame.from_dict(
+        hbase_to_dict(hbase_output, escape_slash=escape_slash), orient="index"
+    )
 
     # Tracklet cell contains null if there is nothing
     # and so HBase won't transfer data -- ignoring the column

--- a/apps/utils/utils.py
+++ b/apps/utils/utils.py
@@ -83,12 +83,12 @@ def check_args(args: list, payload: dict) -> dict:
     Parameters
     ----------
     """
-    required_args = [i["name"] for i in args if i["required"] is True]
+    required_args = [k for k in args if args[k].required is True]
     for required_arg in required_args:
         if required_arg not in payload:
             rep = {
                 "status": "error",
-                "text": f"A value for `{required_arg}` is required. Use GET to check arguments.\n",
+                "text": f"A value for `{required_arg}` is required. See https://api.fink-portal.org \n",
             }
             return rep
     return {"status": "ok"}

--- a/apps/utils/utils.py
+++ b/apps/utils/utils.py
@@ -20,6 +20,7 @@ import yaml
 import requests
 
 from flask import Response
+from flask import make_response
 
 from astropy.table import Table
 from astropy.io import votable
@@ -120,15 +121,19 @@ def send_tabular_data(pdf, output_format):
         vt = votable.from_table(table)
         votable.writeto(vt, f)
         f.seek(0)
-        return f.read()
+        response = make_response(f.read())
+        response.headers.set('Content-Type', 'votable')
+        return response
     elif output_format == "parquet":
         f = io.BytesIO()
         pdf.to_parquet(f)
         f.seek(0)
-        return f.read()
+        response = make_response(f.read())
+        response.headers.set('Content-Type', 'parquet')
+        return response
 
     rep = {
         "status": "error",
-        "text": f"Output format `{output_format}` is not supported. Choose among json, csv, or parquet\n",
+        "text": f"Output format `{output_format}` is not supported. Choose among json, csv, votable, or parquet\n",
     }
     return Response(str(rep), 400)

--- a/apps/utils/utils.py
+++ b/apps/utils/utils.py
@@ -67,6 +67,7 @@ def download_cutout(objectId, candid, kind):
         data = json.loads(r.content)
     else:
         # TODO: different return based on `kind`?
+        logging.warning("Cutout retrieval failed with status {}: {}".format(r.status_code, r.text))
         return []
 
     if kind != "All":

--- a/apps/utils/utils.py
+++ b/apps/utils/utils.py
@@ -18,9 +18,9 @@ import io
 import json
 import yaml
 import requests
+import logging
 
 from flask import Response
-from flask import make_response
 
 from astropy.table import Table
 from astropy.io import votable
@@ -67,7 +67,9 @@ def download_cutout(objectId, candid, kind):
         data = json.loads(r.content)
     else:
         # TODO: different return based on `kind`?
-        logging.warning("Cutout retrieval failed with status {}: {}".format(r.status_code, r.text))
+        logging.warning(
+            "Cutout retrieval failed with status {}: {}".format(r.status_code, r.text)
+        )
         return []
 
     if kind != "All":
@@ -114,12 +116,12 @@ def send_tabular_data(pdf, output_format):
     """
     if output_format == "json":
         response = Response(pdf.to_json(orient="records"), 200)
-        response.headers.set('Content-Type', 'application/json')
+        response.headers.set("Content-Type", "application/json")
         return response
     elif output_format == "csv":
         # TODO: set header?
         response = Response(pdf.to_csv(index=False), 200)
-        response.headers.set('Content-Type', 'application/csv')
+        response.headers.set("Content-Type", "application/csv")
         return response
     elif output_format == "votable":
         f = io.BytesIO()
@@ -127,15 +129,15 @@ def send_tabular_data(pdf, output_format):
         vt = votable.from_table(table)
         votable.writeto(vt, f)
         f.seek(0)
-        response = Reponse(f.read(), 200)
-        response.headers.set('Content-Type', 'votable')
+        response = Response(f.read(), 200)
+        response.headers.set("Content-Type", "votable")
         return response
     elif output_format == "parquet":
         f = io.BytesIO()
         pdf.to_parquet(f)
         f.seek(0)
-        response = Reponse(f.read(), 200)
-        response.headers.set('Content-Type', 'parquet')
+        response = Response(f.read(), 200)
+        response.headers.set("Content-Type", "parquet")
         return response
 
     rep = {

--- a/apps/utils/utils.py
+++ b/apps/utils/utils.py
@@ -112,23 +112,28 @@ def send_tabular_data(pdf, output_format):
         case of error, returns `Response` object.
     """
     if output_format == "json":
-        return pdf.to_json(orient="records")
+        response = Response(pdf.to_json(orient="records"), 200)
+        response.headers.set('Content-Type', 'application/json')
+        return response
     elif output_format == "csv":
-        return pdf.to_csv(index=False)
+        # TODO: set header?
+        response = Response(pdf.to_csv(index=False), 200)
+        response.headers.set('Content-Type', 'application/csv')
+        return response
     elif output_format == "votable":
         f = io.BytesIO()
         table = Table.from_pandas(pdf)
         vt = votable.from_table(table)
         votable.writeto(vt, f)
         f.seek(0)
-        response = make_response(f.read())
+        response = Reponse(f.read(), 200)
         response.headers.set('Content-Type', 'votable')
         return response
     elif output_format == "parquet":
         f = io.BytesIO()
         pdf.to_parquet(f)
         f.seek(0)
-        response = make_response(f.read())
+        response = Reponse(f.read(), 200)
         response.headers.set('Content-Type', 'parquet')
         return response
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 astropy
 flask
+flask-restx
 pandas
 numpy
 fink-filters


### PR DESCRIPTION
This PR introduces the use of [flask_restx](https://flask-restx.readthedocs.io/en/latest/index.html). We notably made a reorganisation in terms of `Namespace` rather than `Blueprint`, and the API documentation is automatically generated by Swagger (https://api.fink-portal.org)