### PR TITLE
Switch from Long to String definition for candid

### DIFF
--- a/apps/routes/cutouts/api.py
+++ b/apps/routes/cutouts/api.py
@@ -38,8 +38,7 @@ ARGS = ns.model(
             description="PNG[default], FITS, array", example="PNG", required=False
         ),
         "candid": fields.Integer(
-            description="Candidate ID of the alert belonging to the object with `objectId`. If not filled, the cutouts of the latest alert is returned",
-            example=2890466950515015016,
+            description="Candidate ID (long integer) of the alert belonging to the object with `objectId`. If not filled, the cutouts of the latest alert is returned",
             required=False,
         ),
         "stretch": fields.String(
@@ -81,7 +80,7 @@ class Cutouts(Resource):
             # POST from query URL
             return self.post()
         else:
-            return Response(ARGS.description, 200)
+            return Response(ns.description, 200)
 
     @ns.expect(ARGS, location="json", as_dict=True)
     def post(self):

--- a/apps/routes/cutouts/api.py
+++ b/apps/routes/cutouts/api.py
@@ -37,8 +37,9 @@ ARGS = ns.model(
         "output-format": fields.String(
             description="PNG[default], FITS, array", example="PNG", required=False
         ),
-        "candid": fields.Integer(
+        "candid": fields.String(
             description="Candidate ID (long integer) of the alert belonging to the object with `objectId`. If not filled, the cutouts of the latest alert is returned",
+            example="2890466950515015016",
             required=False,
         ),
         "stretch": fields.String(

--- a/apps/routes/cutouts/api.py
+++ b/apps/routes/cutouts/api.py
@@ -35,7 +35,7 @@ ARGS = ns.model(
             required=True,
         ),
         "output-format": fields.String(
-            description="PNG[default], FITS, array", example="array", required=False
+            description="PNG[default], FITS, array", example="PNG", required=False
         ),
         "candid": fields.Integer(
             description="Candidate ID of the alert belonging to the object with `objectId`. If not filled, the cutouts of the latest alert is returned",
@@ -71,7 +71,7 @@ ARGS = ns.model(
 )
 
 
-@ns.route("/")
+@ns.route("")
 @ns.doc(params={k: ARGS[k].description for k in ARGS})
 class Cutouts(Resource):
     def get(self):

--- a/apps/routes/objects/api.py
+++ b/apps/routes/objects/api.py
@@ -59,7 +59,7 @@ ARGS = ns.model(
 )
 
 
-@ns.route("/")
+@ns.route("")
 @ns.doc(params={k: ARGS[k].description for k in ARGS})
 class Objects(Resource):
     def get(self):

--- a/apps/routes/objects/api.py
+++ b/apps/routes/objects/api.py
@@ -69,7 +69,7 @@ class Objects(Resource):
             # POST from query URL
             return self.post()
         else:
-            return Response(ARGS.description, 200)
+            return Response(ns.description, 200)
 
     @ns.expect(ARGS, location="json", as_dict=True)
     def post(self):


### PR DESCRIPTION
Closes #13 

Javascript only supporting integers up to 53 bits, we switch the type of the field `candid` from integer to string in Swagger.