### PR TITLE
Add trend option to class search

### DIFF
--- a/apps/routes/v1/latests/api.py
+++ b/apps/routes/v1/latests/api.py
@@ -57,7 +57,7 @@ ARGS = ns.model(
         ),
         "columns": fields.String(
             description="Comma-separated data columns to transfer, e.g. 'i:magpsf,i:jd'. If not specified, transfer all columns.",
-            example="i:objectId,i:jd,i:magpsf,i:fid",
+            example="i:objectId,i:jd,i:magpsf,i:fid,d:mag_rate,d:blazar_stats_m0",
             required=False,
         ),
         "output-format": fields.String(

--- a/apps/routes/v1/latests/api.py
+++ b/apps/routes/v1/latests/api.py
@@ -30,6 +30,11 @@ ARGS = ns.model(
             example="Early SN Ia candidate",
             required=True,
         ),
+        "trend": fields.String(
+            description="Desired trend among: rising, fading.",
+            example="rising",
+            required=False,
+        ),
         "n": fields.Integer(
             description="Last N alerts to transfer between stopping date and starting date. Default is 100.",
             example=10,

--- a/apps/routes/v1/latests/api.py
+++ b/apps/routes/v1/latests/api.py
@@ -31,7 +31,7 @@ ARGS = ns.model(
             required=True,
         ),
         "trend": fields.String(
-            description="Desired trend among: rising, fading.",
+            description="Desired trend among: rising, fading. For `class=(CTA) Blazar`, two specific trends are available: low_state, new_low_state.",
             example="rising",
             required=False,
         ),

--- a/apps/routes/v1/latests/test.py
+++ b/apps/routes/v1/latests/test.py
@@ -27,6 +27,7 @@ APIURL = sys.argv[1]
 def classsearch(
     myclass="Early SN Ia candidate",
     n=10,
+    trend=None,
     startdate=None,
     stopdate=None,
     output_format="json",
@@ -40,6 +41,9 @@ def classsearch(
 
     if cols is not None:
         payload.update({"columns": cols})
+
+    if trend is not None:
+        payload.update({"trend": trend})
 
     r = requests.post("{}/api/v1/latests".format(APIURL), json=payload)
 
@@ -153,6 +157,63 @@ def test_classsearch_and_cols_without_sort() -> None:
     assert len(pdf.columns) == 1, len(pdf.columns)
 
     assert "i:objectId" in pdf.columns
+
+
+def test_general_trends() -> None:
+    """
+    Examples
+    --------
+    >>> test_general_trends()
+    """
+    start = "2024-11-03 12:30:00"
+    stop = "2024-12-03 12:30:00"
+    pdf = classsearch(
+        myclass="Early SN Ia candidate",
+        startdate=start,
+        stopdate=stop,
+    )
+    pdf_rising = classsearch(
+        myclass="Early SN Ia candidate",
+        trend="rising",
+        startdate=start,
+        stopdate=stop,
+    )
+    pdf_fading = classsearch(
+        myclass="Early SN Ia candidate",
+        trend="fading",
+        startdate=start,
+        stopdate=stop,
+    )
+
+    assert len(pdf) == len(pdf_rising) + len(pdf_fading), (len(pdf), len(pdf_rising))
+
+    assert np.all(pdf_rising["d:mag_rate"].to_numpy() < 0)
+    assert np.all(pdf_fading["d:mag_rate"].to_numpy() > 0)
+
+
+def test_blazar_trends() -> None:
+    """
+    Examples
+    --------
+    >>> test_blazar_trends()
+    """
+    start = "2024-11-01 12:30:00"
+    stop = "2024-12-01 12:30:00"
+    pdf_low_state = classsearch(
+        myclass="(CTA) Blazar",
+        trend="low_state",
+        startdate=start,
+        stopdate=stop,
+    )
+    pdf_new_low_state = classsearch(
+        myclass="(CTA) Blazar",
+        trend="new_low_state",
+        startdate=start,
+        stopdate=stop,
+    )
+
+    assert len(pdf_low_state) == 5, len(pdf_low_state)
+    assert len(pdf_new_low_state) == 0  # to be changed later
 
 
 def test_query_url() -> None:

--- a/apps/routes/v1/latests/utils.py
+++ b/apps/routes/v1/latests/utils.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from flask import Response
+
 import pandas as pd
 from astropy.time import Time
 
@@ -45,7 +47,10 @@ def extract_object_from_class(payload: dict, return_raw: bool = False) -> pd.Dat
         """.format(payload["trend"])
         return Response(msg, 400)
 
-    if payload.get("trend", None) == "low_state" and payload.get("class", None) != "(CTA) Blazar":
+    if (
+        payload.get("trend", None) == "low_state"
+        and payload.get("class", None) != "(CTA) Blazar"
+    ):
         msg = """
         low_state trend is only implemented for the `(CTA) Blazar` class.
         {} class can accept trend among: rising, fading.

--- a/apps/routes/v1/latests/utils.py
+++ b/apps/routes/v1/latests/utils.py
@@ -40,21 +40,21 @@ def extract_object_from_class(payload: dict, return_raw: bool = False) -> pd.Dat
     ----------
     out: pandas dataframe
     """
-    if "trend" in payload and payload["trend"] not in ["rising", "fading", "low_state"]:
+    if "trend" in payload and payload["trend"] not in ["rising", "fading", "low_state", "new_low_state"]:
         msg = """
         {} is not a valid trend.
-        Trend must be among: rising, fading, low_state
+        Trend must be among: rising, fading, low_state, new_low_state
         """.format(payload["trend"])
         return Response(msg, 400)
 
     if (
-        payload.get("trend", None) == "low_state"
+        payload.get("trend", None) in ["low_state", "new_low_state"]
         and payload.get("class", None) != "(CTA) Blazar"
     ):
         msg = """
-        low_state trend is only implemented for the `(CTA) Blazar` class.
+        {} trend is only implemented for the `(CTA) Blazar` class.
         {} class can accept trend among: rising, fading.
-        """.format(payload["class"])
+        """.format(payload["trend"], payload["class"])
         return Response(msg, 400)
 
     if "n" not in payload:
@@ -176,5 +176,8 @@ def extract_object_from_class(payload: dict, return_raw: bool = False) -> pd.Dat
         pdf = pdf[pdf["d:mag_rate"] < 0]
     elif payload.get("trend", None) == "fading":
         pdf = pdf[pdf["d:mag_rate"] > 0]
+    elif payload.get("trend", None) == "new_low_state":
+        # TODO: use fink-filters directly
+        pdf = pdf[pdf["d:blazar_stats_m0"] >= 1]
 
     return pdf

--- a/apps/routes/v1/latests/utils.py
+++ b/apps/routes/v1/latests/utils.py
@@ -40,7 +40,12 @@ def extract_object_from_class(payload: dict, return_raw: bool = False) -> pd.Dat
     ----------
     out: pandas dataframe
     """
-    if "trend" in payload and payload["trend"] not in ["rising", "fading", "low_state", "new_low_state"]:
+    if "trend" in payload and payload["trend"] not in [
+        "rising",
+        "fading",
+        "low_state",
+        "new_low_state",
+    ]:
         msg = """
         {} is not a valid trend.
         Trend must be among: rising, fading, low_state, new_low_state

--- a/assets/fink_types.csv
+++ b/assets/fink_types.csv
@@ -6,3 +6,4 @@ Tracklet
 Solar System MPC
 Solar System candidate
 Ambiguous
+(CTA) Blazar


### PR DESCRIPTION
Closes #47 

Actually -- we did not implement a new endpoint. Rather, we add an option to the class search.

## Available trends

The current available trends for all classes are: `rising`, `fading`.

## New (CTA) Blazar class

A new class has also been added: `(CTA) Blazar`, under the Fink category. This corresponds to a list of Blazars selected by CTAO for their lack of redshift. Currently, only Blazars in this list that we found in low state are searchable (current use case). 

This class comes with two specific trends: `low_state` and `new_low_state`. Later, we plan to add more trend such as `flaring`.

## To do later

1. It would be nice to combine trends, e.g. `rising,low_state`
2. Adding more trends: `pure`, `non-pure`, `last_alert`