### PR TITLE
Force i:ssnamenr to be in the payload

### DIFF
--- a/apps/routes/v1/sso/test.py
+++ b/apps/routes/v1/sso/test.py
@@ -1,4 +1,4 @@
-# Copyright 2022 AstroLab Software
+# Copyright 2022-2025 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/apps/routes/v1/sso/utils.py
+++ b/apps/routes/v1/sso/utils.py
@@ -72,6 +72,15 @@ def extract_sso_data(payload: dict) -> pd.DataFrame:
     ):
         with_cutouts = True
 
+    if with_cutouts and truncated:
+        # Check mandatory fields
+        if "i:objectId" not in cols or "i:candid" not in cols:
+            rep = {
+                "status": "error",
+                "text": "You need to add 'i:objectId,i:candid' to the columns.\n",
+            }
+            return Response(str(rep), 400)
+
     n_or_d = str(payload["n_or_d"])
 
     if "," in n_or_d:

--- a/apps/routes/v1/sso/utils.py
+++ b/apps/routes/v1/sso/utils.py
@@ -81,6 +81,9 @@ def extract_sso_data(payload: dict) -> pd.DataFrame:
             }
             return Response(str(rep), 400)
 
+    if truncated and "i:ssnamenr" not in cols:
+        cols += ",i:ssnamenr"
+
     n_or_d = str(payload["n_or_d"])
 
     if "," in n_or_d:

--- a/apps/routes/v1/sso/utils.py
+++ b/apps/routes/v1/sso/utils.py
@@ -82,6 +82,8 @@ def extract_sso_data(payload: dict) -> pd.DataFrame:
             return Response(str(rep), 400)
 
     if truncated and "i:ssnamenr" not in cols:
+        # For name resolving, i:ssnamenr must be here
+        # In case the user forgot, let's add it silently
         cols += ",i:ssnamenr"
 
     n_or_d = str(payload["n_or_d"])
@@ -199,14 +201,12 @@ def extract_sso_data(payload: dict) -> pd.DataFrame:
                 download_cutout(row["i:objectId"], row["i:candid"], cutout_kind)
             )
         pdf[colname] = cutouts
-        # pdf[colname] = pdf[["i:objectId", "i:candid"]].apply(
-        #    lambda x: pd.Series([download_cutout(x.iloc[0], x.iloc[1], cutout_kind)]),
-        #    axis=1,
-        # )
 
     if with_ephem:
-        # We should probably add a timeout
-        # and try/except in case of miriade shutdown
+        # TODO: In case truncated is True, check (before DB call)
+        #       the mandatory fields have been requested
+        # TODO: We should probably add a timeout and try/except
+        #       in case of miriade shutdown
         pdf = get_miriade_data(pdf, sso_colname="sso_name")
         if "i:magpsf_red" not in pdf.columns:
             rep = {
@@ -216,13 +216,11 @@ def extract_sso_data(payload: dict) -> pd.DataFrame:
             return Response(str(rep), 400)
 
     if with_residuals:
-        # get phase curve parameters using
-        # the sHG1G2 model
+        # TODO: In case truncated is True, check (before DB call)
+        #       the mandatory fields have been requested
 
-        # Phase angle, in radians
+        # Get phase curve parameters using the sHG1G2 model
         phase = np.deg2rad(pdf["Phase"].values)
-
-        # Required for sHG1G2
         ra = np.deg2rad(pdf["i:ra"].values)
         dec = np.deg2rad(pdf["i:dec"].values)
 


### PR DESCRIPTION
Closes #57 

When selecting fields to return, if `i:ssnamenr` is not present, the API crashes because name resolving fails. There were two options at this point:
1. skipping name resolving
2. forcing `i:ssnamenr` to be present in the payload

The first option may seem like the natural choice at first glance, but I believe it would confuse the user more than it would help. Since an object can have multiple designations, what would be the point of providing only a fraction of the data? Additionally, having different code behavior based on the input fields is probably not wise.

So I opted for the second option. If the user selected fields to return (which is a very good practice!) but `i:ssnamenr` is not present, we add it. Note that it has only a limited impact on the performance (one more field to get from the database).