### PR TITLE
[Rubin] New column family scheme

### DIFF
--- a/apps/routes/v1/lsst/conesearch/utils.py
+++ b/apps/routes/v1/lsst/conesearch/utils.py
@@ -47,10 +47,10 @@ def run_conesearch(payload: dict) -> pd.DataFrame:
     """
     if "columns" in payload:
         cols = payload["columns"].replace(" ", "")
-        if "s:ra" not in cols:
-            cols = ",".join([cols, "s:ra"])
-        if "s:dec" not in cols:
-            cols = ",".join([cols, "s:dec"])
+        if "r:ra" not in cols:
+            cols = ",".join([cols, "r:ra"])
+        if "r:dec" not in cols:
+            cols = ",".join([cols, "r:dec"])
     else:
         cols = "*"
 
@@ -132,25 +132,25 @@ def run_conesearch(payload: dict) -> pd.DataFrame:
     if "startdate" in payload:
         # Filter out alerts that vary in the past
         mjd_start = Time(isoify_time(payload["startdate"]), scale="tai").mjd
-        pdf = pdf[pdf["o:firstDiaSourceMjdTai"] >= mjd_start]
+        pdf = pdf[pdf["r:firstDiaSourceMjdTai"] >= mjd_start]
 
         if "window" in payload:
             # Also filter out alerts that vary in the future
             window = float(payload["window"])
             mjd_stop = mjd_start + window
-            pdf = pdf[pdf["o:lastDiaSourceMjdTai"] <= mjd_stop]
+            pdf = pdf[pdf["r:lastDiaSourceMjdTai"] <= mjd_stop]
 
     if "stopdate" in payload:
         # Filter out alerts that vary in the future
         mjd_stop = Time(isoify_time(payload["stopdate"]), scale="tai").mjd
-        pdf = pdf[pdf["o:lastDiaSourceMjdTai"] <= mjd_stop]
+        pdf = pdf[pdf["r:lastDiaSourceMjdTai"] <= mjd_stop]
 
     # For conesearch, sort by distance
     if len(pdf) > 0:
         sep = coord.separation(
             SkyCoord(
-                pdf["s:ra"],
-                pdf["s:dec"],
+                pdf["r:ra"],
+                pdf["r:dec"],
                 unit="deg",
             ),
         ).deg

--- a/apps/routes/v1/lsst/cutouts/utils.py
+++ b/apps/routes/v1/lsst/cutouts/utils.py
@@ -88,7 +88,7 @@ def format_and_send_cutout(payload: dict):
     results = client.scan(
         "",
         rowkey,
-        "r:hdfs_path,s:midpointMjdTai,s:diaSourceId,o:diaObjectId",
+        "r:hdfs_path,r:midpointMjdTai,r:diaSourceId,r:diaObjectId",
         0,
         False,
         False,
@@ -110,7 +110,7 @@ def format_and_send_cutout(payload: dict):
     json_payload = {}
     # Extract only the alert of interest
     if "diaSourceId" in payload:
-        mask = pdf["s:diaSourceId"].astype(str) == str(payload["diaSourceId"])
+        mask = pdf["r:diaSourceId"].astype(str) == str(payload["diaSourceId"])
         json_payload.update({"diaSourceId": str(payload["diaSourceId"])})
         pos_target = np.where(mask)[0][0]
     else:
@@ -122,7 +122,7 @@ def format_and_send_cutout(payload: dict):
         {
             "hdfsPath": pdf["r:hdfs_path"].to_numpy()[pos_target].split(":8020")[1],
             "kind": payload["kind"],
-            "diaObjectId": str(pdf["o:diaObjectId"].to_numpy()[pos_target]),
+            "diaObjectId": str(pdf["r:diaObjectId"].to_numpy()[pos_target]),
         }
     )
 

--- a/apps/routes/v1/lsst/objects/test.py
+++ b/apps/routes/v1/lsst/objects/test.py
@@ -93,7 +93,7 @@ def test_column_selection() -> None:
     --------
     >>> test_column_selection()
     """
-    pdf = get_an_object(oid=OID, columns="o:nDiaSources,o:firstDiaSourceMjdTai")
+    pdf = get_an_object(oid=OID, columns="r:nDiaSources,r:firstDiaSourceMjdTai")
 
     assert len(pdf.columns) == 2, "I count {} columns".format(len(pdf.columns))
 
@@ -119,14 +119,14 @@ def test_multiple_objects() -> None:
     OIDS = ",".join(OIDS_)
     pdf = get_an_object(oid=OIDS)
 
-    n_oids = len(np.unique(pdf.groupby("o:diaObjectId").count()["o:ra"]))
+    n_oids = len(np.unique(pdf.groupby("r:diaObjectId").count()["r:ra"]))
     assert n_oids == 3
 
     n_oids_single = 0
     len_object = 0
     for oid in OIDS_:
         pdf_ = get_an_object(oid=oid)
-        n_oid = len(np.unique(pdf_.groupby("o:diaObjectId").count()["o:ra"]))
+        n_oid = len(np.unique(pdf_.groupby("r:diaObjectId").count()["r:ra"]))
         n_oids_single += n_oid
         len_object += len(pdf_)
 

--- a/apps/routes/v1/lsst/sources/test.py
+++ b/apps/routes/v1/lsst/sources/test.py
@@ -106,7 +106,7 @@ def test_column_selection() -> None:
     --------
     >>> test_column_selection()
     """
-    pdf = get_an_object(oid=OID, columns="s:midpointMjdTai,s:psfFlux")
+    pdf = get_an_object(oid=OID, columns="r:midpointMjdTai,r:psfFlux")
 
     assert len(pdf.columns) == 2, "I count {} columns".format(len(pdf.columns))
 
@@ -120,11 +120,11 @@ def test_formatting() -> None:
     pdf = get_an_object(oid=OID)
 
     # stupid python cast...
-    assert isinstance(pdf["s:band"].to_numpy()[0], str), type(
-        pdf["s:band"].to_numpy()[0]
+    assert isinstance(pdf["r:band"].to_numpy()[0], str), type(
+        pdf["r:band"].to_numpy()[0]
     )
-    assert isinstance(pdf["s:psfFlux"].to_numpy()[0], np.double), type(
-        pdf["s:psfFlux"].to_numpy()[0]
+    assert isinstance(pdf["r:psfFlux"].to_numpy()[0], np.double), type(
+        pdf["r:psfFlux"].to_numpy()[0]
     )
 
 
@@ -135,7 +135,7 @@ def test_misc() -> None:
     >>> test_misc()
     """
     pdf = get_an_object(oid=OID)
-    assert np.all(pdf["s:midpointMjdTai"].to_numpy() > 0)
+    assert np.all(pdf["r:midpointMjdTai"].to_numpy() > 0)
 
 
 def test_bad_request() -> None:
@@ -159,16 +159,16 @@ def test_multiple_objects() -> None:
     OIDS = ",".join(OIDS_)
     pdf = get_an_object(oid=OIDS)
     assert not pdf.empty, OIDS
-    assert "s:diaObjectId" in pdf.columns, pdf.columns
+    assert "r:diaObjectId" in pdf.columns, pdf.columns
 
-    n_oids = len(np.unique(pdf.groupby("s:diaObjectId").count()["s:ra"]))
+    n_oids = len(np.unique(pdf.groupby("r:diaObjectId").count()["r:ra"]))
     assert n_oids == 2
 
     n_oids_single = 0
     len_object = 0
     for oid in OIDS_:
         pdf_ = get_an_object(oid=oid)
-        n_oid = len(np.unique(pdf_.groupby("s:diaObjectId").count()["s:ra"]))
+        n_oid = len(np.unique(pdf_.groupby("r:diaObjectId").count()["r:ra"]))
         n_oids_single += n_oid
         len_object += len(pdf_)
 

--- a/apps/utils/decoding.py
+++ b/apps/utils/decoding.py
@@ -194,7 +194,7 @@ def format_lsst_hbase_output(
     pdfs = pdfs.replace(to_replace={"true": True, "false": False})
 
     # cast 'nan' into `[]` for easier json decoding
-    for col in ["fs:lc_features_g", "fs:lc_features_r"]:
+    for col in ["f:lc_features_g", "f:lc_features_r"]:
         if col in pdfs.columns:
             pdfs[col] = pdfs[col].replace("nan", "[]")
 
@@ -203,15 +203,15 @@ def format_lsst_hbase_output(
     # Display only the last alert
     if (
         group_alerts
-        and ("s:midpointMjdTai" in pdfs.columns)
-        and ("s:diaObjectId" in pdfs.columns)
+        and ("r:midpointMjdTai" in pdfs.columns)
+        and ("r:diaObjectId" in pdfs.columns)
     ):
-        pdfs["s:midpointMjdTai"] = pdfs["s:midpointMjdTai"].astype(float)
-        pdfs = pdfs.loc[pdfs.groupby("s:diaObjectId")["s:midpointMjdTai"].idxmax()]
+        pdfs["r:midpointMjdTai"] = pdfs["r:midpointMjdTai"].astype(float)
+        pdfs = pdfs.loc[pdfs.groupby("r:diaObjectId")["r:midpointMjdTai"].idxmax()]
 
     # sort values by time
-    if "s:midpointMjdTai" in pdfs.columns:
-        pdfs = pdfs.sort_values("s:midpointMjdTai", ascending=False)
+    if "r:midpointMjdTai" in pdfs.columns:
+        pdfs = pdfs.sort_values("r:midpointMjdTai", ascending=False)
 
     return pdfs
 


### PR DESCRIPTION
In #77 we introduced a new column family scheme, with up to 4 cf per table. Unfortunately, this is consuming too much heap when writing data to HBase, as there is one memstore per cf! Hence, we decided to reduce to maximum 2 cf per table, based on the data provenance:
- `r`: Rubin provided data
- `f`: Fink added value data