### PR TITLE
[Rubin] Simple SSO route

### DIFF
--- a/app_lsst.py
+++ b/app_lsst.py
@@ -25,6 +25,7 @@ from apps.routes.v1.lsst.objects.api import ns as ns_objects
 from apps.routes.v1.lsst.conesearch.api import ns as ns_conesearch
 from apps.routes.v1.lsst.cutouts.api import ns as ns_cutouts
 from apps.routes.v1.lsst.schema.api import ns as ns_schema
+from apps.routes.v1.lsst.sso.api import ns as ns_sso
 
 config = extract_configuration("config.yml")
 
@@ -61,6 +62,7 @@ api.add_namespace(ns_objects)
 api.add_namespace(ns_conesearch)
 api.add_namespace(ns_cutouts)
 api.add_namespace(ns_schema)
+api.add_namespace(ns_sso)
 
 # Register blueprint
 app.register_blueprint(blueprint)

--- a/apps/routes/v1/lsst/schema/utils.py
+++ b/apps/routes/v1/lsst/schema/utils.py
@@ -234,6 +234,18 @@ def extract_schema(payload: dict) -> Response:
                     for i in flatten_nested(rubin_schema, "ssSource") + root_list
                 }
             ),
+            "Fink science module outputs (f:)": sort_dict(
+                {
+                    i["name"]: {"type": i["type"], "doc": i.get("doc", "TBD")}
+                    for i in [
+                        {
+                            "name": "sso_name",
+                            "type": "str",
+                            "doc": "Resolved name from quaero",
+                        }  # Manual entry from the /api/v1/sso route
+                    ]
+                }
+            ),
         }
 
     response = Response(json.dumps(types), 200)

--- a/apps/routes/v1/lsst/schema/utils.py
+++ b/apps/routes/v1/lsst/schema/utils.py
@@ -226,7 +226,6 @@ def extract_schema(payload: dict) -> Response:
             ),
         }
     elif payload["endpoint"] == "/api/v1/sso":
-        # FIXME: what about MPCORB & ssObject?
         types = {
             "Rubin original fields (r:)": sort_dict(
                 {

--- a/apps/routes/v1/lsst/schema/utils.py
+++ b/apps/routes/v1/lsst/schema/utils.py
@@ -50,6 +50,7 @@ def extract_schema(payload: dict) -> Response:
 
     """
     # LSST candidate fields
+    # FIXME: allow user to input a version?
     r = requests.get(
         "https://usdf-alert-schemas-dev.slac.stanford.edu/subjects/alert-packet/versions/latest/schema"
     )

--- a/apps/routes/v1/lsst/sso/api.py
+++ b/apps/routes/v1/lsst/sso/api.py
@@ -1,0 +1,94 @@
+# Copyright 2025 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from flask import Response, request
+from flask_restx import Namespace, Resource, fields
+
+from apps.routes.v1.lsst.sso.utils import extract_sso_data
+
+from apps.utils.utils import check_args
+from apps.utils.utils import send_tabular_data
+
+
+ns = Namespace(
+    "api/v1/sso",
+    "Retrieve Solar System object data from Fink/Rubin based on their number or designation",
+)
+
+ARGS = ns.model(
+    "sso",
+    {
+        "n_or_d": fields.String(
+            description="IAU number of the object, or designation of the object IF the number does not exist yet. Packed form is allowed (e.g. K15W16Q). Example for numbers: 8467 (asteroid) or 10P (comet). Example for designations: 2010JO69 (asteroid) or C/2020V2 (comet). You can also give a list of object names (comma-separated).",
+            example="8467",
+            required=True,
+        ),
+        "withEphem": fields.Boolean(
+            description="Attach ephemerides provided by the Miriade service (https://ssp.imcce.fr/webservices/miriade/api/ephemcc/), as extra columns in the results.",
+            example=False,
+            required=False,
+        ),
+        "withResiduals": fields.Boolean(
+            description="Return the residuals `obs - model` using the sHG1G2 phase curve model. Work only for a single object query (`n_or_d` cannot be a list).",
+            example=False,
+            required=False,
+        ),
+        "columns": fields.String(
+            description="Comma-separated data columns to transfer, e.g. 'r:midpointMjdTai,r:scienceFlux,r:band,r:ra,r:dec'. If not specified, transfer all columns.",
+            example="r:midpointMjdTai,r:scienceFlux,r:band,r:ra,r:dec",
+            required=False,
+        ),
+        "output-format": fields.String(
+            description="Output format among json[default], csv, parquet, votable.",
+            example="json",
+            required=False,
+        ),
+    },
+)
+
+
+@ns.route("")
+@ns.doc(params={k: ARGS[k].description for k in ARGS})
+class Solarsystem(Resource):
+    def get(self):
+        """Retrieve Solar System object data from Fink/Rubin based on their number or designation"""
+        payload = request.args
+        if len(payload) > 0:
+            # POST from query URL
+            return self.post()
+        else:
+            return Response(ns.description, 200)
+
+    @ns.expect(ARGS, location="json", as_dict=True)
+    def post(self):
+        """Retrieve Solar System object data from Fink/Rubin based on their number or designation"""
+        # get payload from the query URL
+        payload = request.args
+
+        if payload is None or len(payload) == 0:
+            # if no payload, try the JSON blob
+            payload = request.json
+
+        rep = check_args(ARGS, payload)
+        if rep["status"] != "ok":
+            return Response(str(rep), 400)
+
+        out = extract_sso_data(payload)
+
+        # Error propagation
+        if isinstance(out, Response):
+            return out
+
+        output_format = payload.get("output-format", "json")
+        return send_tabular_data(out, output_format)

--- a/apps/routes/v1/lsst/sso/utils.py
+++ b/apps/routes/v1/lsst/sso/utils.py
@@ -99,10 +99,10 @@ def extract_sso_data(payload: dict) -> pd.DataFrame:
     n_or_d = str(payload["n_or_d"])
 
     if "," in n_or_d:
-        ids = n_or_d.replace(" ", "").split(",")
+        ids = [i.strip() for i in n_or_d.split(",")]
         multiple_objects = True
     else:
-        ids = [n_or_d.replace(" ", "")]
+        ids = [n_or_d.strip()]
         multiple_objects = False
 
     # We cannot do multi-object and phase curve computation

--- a/apps/routes/v1/lsst/sso/utils.py
+++ b/apps/routes/v1/lsst/sso/utils.py
@@ -24,8 +24,8 @@ from apps.utils.utils import (
 from apps.utils.client import connect_to_hbase_table
 from apps.utils.decoding import format_hbase_output
 
-from fink_utils.sso.miriade import get_miriade_data
-from fink_utils.sso.spins import func_hg1g2_with_spin, estimate_sso_params
+# from fink_utils.sso.miriade import get_miriade_data
+# from fink_utils.sso.spins import func_hg1g2_with_spin, estimate_sso_params
 
 from line_profiler import profile
 

--- a/apps/routes/v1/lsst/sso/utils.py
+++ b/apps/routes/v1/lsst/sso/utils.py
@@ -1,0 +1,236 @@
+# Copyright 2025 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import requests
+from flask import Response
+
+import pandas as pd
+import numpy as np
+
+from apps.utils.utils import (
+    resolve_sso_name,
+)
+from apps.utils.client import connect_to_hbase_table
+from apps.utils.decoding import format_hbase_output
+
+from fink_utils.sso.miriade import get_miriade_data
+from fink_utils.sso.spins import func_hg1g2_with_spin, estimate_sso_params
+
+from line_profiler import profile
+
+def resolve_packed(n_or_d):
+    """Resolve all packed names corresponding to input n_or_d"""
+    n_or_d = str(n_or_d)
+    # check if the object is an asteroid or a comet
+    if n_or_d.startswith("C/") or n_or_d.endswith("P"):
+        obj_type = "Comet"
+    else:
+        obj_type = "Asteroid"
+
+    # Pure quaero implementation
+    r = requests.get(
+        "https://api.ssodnet.imcce.fr/quaero/1/sso?q={}&type={}".format(
+            n_or_d.replace(" ", "_"), obj_type
+        )
+    )
+    if r.status_code == 200 and r.json() != []:
+        if r.json()["total"] > 0:
+            sso_name = r.json()["data"][0]["name"]
+
+            aliases = r.json()["data"][0]["aliases"]
+
+            # The provisional designation stored on the orbit and
+            # observations is stored in a 7-character packed format
+            aliases = [al for al in aliases if len(al) == 7]
+
+            return sso_name, aliases
+    return "", []
+
+
+@profile
+def extract_sso_data(payload: dict) -> pd.DataFrame:
+    """Extract data returned by HBase and format it in a Pandas dataframe
+
+    Data is from /api/v1/sso
+
+    Parameters
+    ----------
+    payload: dict
+        See https://api.fink-portal.org
+
+    Return
+    ----------
+    out: pandas dataframe
+    """
+    if "columns" in payload:
+        cols = payload["columns"].replace(" ", "")
+    else:
+        cols = "*"
+
+    if cols == "*":
+        truncated = False
+    else:
+        truncated = True
+
+    with_ephem, with_residuals, with_cutouts = False, False, False
+    if "withResiduals" in payload and (
+        payload["withResiduals"] == "True" or payload["withResiduals"] is True
+    ):
+        with_residuals = True
+        with_ephem = True
+    if "withEphem" in payload and (
+        payload["withEphem"] == "True" or payload["withEphem"] is True
+    ):
+        with_ephem = True
+
+    if truncated and "r:mpcDesignation" not in cols:
+        # For name resolving, i:ssnamenr must be here
+        # In case the user forgot, let's add it silently
+        cols += ",r:mpcDesignation"
+
+    n_or_d = str(payload["n_or_d"])
+
+    if "," in n_or_d:
+        ids = n_or_d.replace(" ", "").split(",")
+        multiple_objects = True
+    else:
+        ids = [n_or_d.replace(" ", "")]
+        multiple_objects = False
+
+    # We cannot do multi-object and phase curve computation
+    if multiple_objects and with_residuals:
+        rep = {
+            "status": "error",
+            "text": "You cannot request residuals for a list object names.\n",
+        }
+        return Response(str(rep), 400)
+
+    # Get all ssnamenrs
+    packed = []
+    sso_names = {}
+    for id_ in ids:
+        sso_name, aliases = resolve_packed(id_)
+
+        if sso_name == "":
+            rep = {
+                "status": "error",
+                "text": "{} is not a valid name or number according to quaero.\n".format(
+                    id_
+                ),
+            }
+            return Response(str(rep), 400)
+
+        if len(aliases) == 0:
+            rep = {
+                "status": "error",
+                "text": "We have found 0 packed designation in the aliases for the object {} according to quaero.\n".format(
+                    id_
+                ),
+            }
+            return Response(str(rep), 400)
+
+        packed += aliases
+        sso_names[id_] = sso_name
+
+    # Get data from the main table
+    client = connect_to_hbase_table("ztf.ssnamenr")
+    results = {}
+    for element in packed:
+        salt = element[1:3]
+        result = client.scan(
+            "",
+            f"key:key:{salt}_{element}_",
+            cols,
+            0,
+            True,
+            True,
+        )
+        results.update(result)
+
+    schema_client = client.schema()
+
+    # reset the limit in case it has been changed above
+    client.close()
+
+    if len(results) == 0:
+        return pd.DataFrame()
+
+    pdf = format_hbase_output(
+        results,
+        schema_client,
+        group_alerts=False,
+        truncated=truncated,
+        extract_color=False,
+    )
+
+    # if with_ephem:
+    #     # TODO: In case truncated is True, check (before DB call)
+    #     #       the mandatory fields have been requested
+    #     # TODO: We should probably add a timeout and try/except
+    #     #       in case of miriade shutdown
+    #     pdf = get_miriade_data(pdf, sso_colname="sso_name")
+    #     if "i:magpsf_red" not in pdf.columns:
+    #         rep = {
+    #             "status": "error",
+    #             "text": "We could not obtain the ephemerides information. Check Miriade availabilities.",
+    #         }
+    #         return Response(str(rep), 400)
+
+    # if with_residuals:
+    #     # TODO: In case truncated is True, check (before DB call)
+    #     #       the mandatory fields have been requested
+
+    #     # Get phase curve parameters using the sHG1G2 model
+    #     phase = np.deg2rad(pdf["Phase"].values)
+    #     ra = np.deg2rad(pdf["i:ra"].values)
+    #     dec = np.deg2rad(pdf["i:dec"].values)
+
+    #     outdic = estimate_sso_params(
+    #         magpsf_red=pdf["i:magpsf_red"].to_numpy(),
+    #         sigmapsf=pdf["i:sigmapsf"].to_numpy(),
+    #         phase=phase,
+    #         filters=pdf["i:fid"].to_numpy(),
+    #         ra=ra,
+    #         dec=dec,
+    #         p0=[15.0, 0.15, 0.15, 0.8, np.pi, 0.0],
+    #         bounds=(
+    #             [-3, 0, 0, 3e-1, 0, -np.pi / 2],
+    #             [30, 1, 1, 1, 2 * np.pi, np.pi / 2],
+    #         ),
+    #         model="SHG1G2",
+    #         normalise_to_V=False,
+    #     )
+
+    #     # check if fit converged else return NaN
+    #     if outdic["fit"] != 0:
+    #         pdf["residuals_shg1g2"] = np.nan
+    #     else:
+    #         # per filter construction of the residual
+    #         pdf["residuals_shg1g2"] = 0.0
+    #         for filt in np.unique(pdf["i:fid"]):
+    #             cond = pdf["i:fid"] == filt
+    #             model = func_hg1g2_with_spin(
+    #                 [phase[cond], ra[cond], dec[cond]],
+    #                 outdic["H_{}".format(filt)],
+    #                 outdic["G1_{}".format(filt)],
+    #                 outdic["G2_{}".format(filt)],
+    #                 outdic["R"],
+    #                 np.deg2rad(outdic["alpha0"]),
+    #                 np.deg2rad(outdic["delta0"]),
+    #             )
+    #             pdf.loc[cond, "residuals_shg1g2"] = (
+    #                 pdf.loc[cond, "i:magpsf_red"] - model
+    #             )
+
+    return pdf

--- a/apps/routes/v1/lsst/sso/utils.py
+++ b/apps/routes/v1/lsst/sso/utils.py
@@ -141,7 +141,7 @@ def extract_sso_data(payload: dict) -> pd.DataFrame:
         sso_names[id_] = sso_name
 
     # Get data from the main table
-    client = connect_to_hbase_table("ztf.ssnamenr")
+    client = connect_to_hbase_table("rubin.diaSource_sso")
     results = {}
     for element in packed:
         salt = element[1:3]

--- a/apps/routes/v1/lsst/sso/utils.py
+++ b/apps/routes/v1/lsst/sso/utils.py
@@ -16,11 +16,7 @@ import requests
 from flask import Response
 
 import pandas as pd
-import numpy as np
 
-from apps.utils.utils import (
-    resolve_sso_name,
-)
 from apps.utils.client import connect_to_hbase_table
 from apps.utils.decoding import format_hbase_output
 
@@ -28,6 +24,7 @@ from apps.utils.decoding import format_hbase_output
 # from fink_utils.sso.spins import func_hg1g2_with_spin, estimate_sso_params
 
 from line_profiler import profile
+
 
 def resolve_packed(n_or_d):
     """Resolve all packed names corresponding to input n_or_d"""

--- a/apps/routes/v1/lsst/sso/utils.py
+++ b/apps/routes/v1/lsst/sso/utils.py
@@ -80,7 +80,7 @@ def extract_sso_data(payload: dict) -> pd.DataFrame:
     else:
         truncated = True
 
-    with_ephem, with_residuals = False, False, False
+    with_ephem, with_residuals = False, False
     if "withResiduals" in payload and (
         payload["withResiduals"] == "True" or payload["withResiduals"] is True
     ):

--- a/apps/routes/v1/lsst/sso/utils.py
+++ b/apps/routes/v1/lsst/sso/utils.py
@@ -18,7 +18,7 @@ from flask import Response
 import pandas as pd
 
 from apps.utils.client import connect_to_hbase_table
-from apps.utils.decoding import format_hbase_output
+from apps.utils.decoding import format_lsst_hbase_output
 
 # from fink_utils.sso.miriade import get_miriade_data
 # from fink_utils.sso.spins import func_hg1g2_with_spin, estimate_sso_params
@@ -163,7 +163,7 @@ def extract_sso_data(payload: dict) -> pd.DataFrame:
     if len(results) == 0:
         return pd.DataFrame()
 
-    pdf = format_hbase_output(
+    pdf = format_lsst_hbase_output(
         results,
         schema_client,
         group_alerts=False,

--- a/apps/routes/v1/lsst/sso/utils.py
+++ b/apps/routes/v1/lsst/sso/utils.py
@@ -89,7 +89,7 @@ def extract_sso_data(payload: dict) -> pd.DataFrame:
     if "withEphem" in payload and (
         payload["withEphem"] == "True" or payload["withEphem"] is True
     ):
-        with_ephem = True
+        with_ephem = True  # noqa: F841
 
     if truncated and "r:mpcDesignation" not in cols:
         # For name resolving, i:ssnamenr must be here

--- a/apps/routes/v1/lsst/sso/utils.py
+++ b/apps/routes/v1/lsst/sso/utils.py
@@ -80,7 +80,7 @@ def extract_sso_data(payload: dict) -> pd.DataFrame:
     else:
         truncated = True
 
-    with_ephem, with_residuals, with_cutouts = False, False, False
+    with_ephem, with_residuals = False, False, False
     if "withResiduals" in payload and (
         payload["withResiduals"] == "True" or payload["withResiduals"] is True
     ):
@@ -138,7 +138,8 @@ def extract_sso_data(payload: dict) -> pd.DataFrame:
             return Response(str(rep), 400)
 
         packed += aliases
-        sso_names[id_] = sso_name
+        for alias in aliases:
+            sso_names[alias] = sso_name
 
     # Get data from the main table
     client = connect_to_hbase_table("rubin.diaSource_sso")
@@ -170,6 +171,9 @@ def extract_sso_data(payload: dict) -> pd.DataFrame:
         truncated=truncated,
         extract_color=False,
     )
+
+    # Propagate transformation
+    pdf["f:sso_name"] = pdf["r:mpcDesignation"].apply(lambda x: sso_names[x])
 
     # if with_ephem:
     #     # TODO: In case truncated is True, check (before DB call)


### PR DESCRIPTION
This PR adds a new route for Rubin to get SSO lightcurve data `api/v1/sso`. The schema route has been updated. Ephemerides and residuals options are not yet available.