### PR TITLE
[Rubin] Resolver route

### DIFF
--- a/app_lsst.py
+++ b/app_lsst.py
@@ -26,6 +26,7 @@ from apps.routes.v1.lsst.conesearch.api import ns as ns_conesearch
 from apps.routes.v1.lsst.cutouts.api import ns as ns_cutouts
 from apps.routes.v1.lsst.schema.api import ns as ns_schema
 from apps.routes.v1.lsst.sso.api import ns as ns_sso
+from apps.routes.v1.lsst.resolver.api import ns as ns_resolver
 
 config = extract_configuration("config.yml")
 
@@ -63,6 +64,7 @@ api.add_namespace(ns_conesearch)
 api.add_namespace(ns_cutouts)
 api.add_namespace(ns_schema)
 api.add_namespace(ns_sso)
+api.add_namespace(ns_resolver)
 
 # Register blueprint
 app.register_blueprint(blueprint)

--- a/app_ztf.py
+++ b/app_ztf.py
@@ -38,7 +38,7 @@ from apps.routes.v1.ztf.metadata.api import ns as ns_metadata
 
 config = extract_configuration("config.yml")
 
-app = Flask("Fink REST API")
+app = Flask("Fink/ZTF REST API")
 metrics = GunicornPrometheusMetrics(app)
 
 # Master blueprint
@@ -46,7 +46,7 @@ blueprint = Blueprint("api", __name__, url_prefix="/")
 api = Api(
     blueprint,
     version=__version__,
-    title="Fink object API",
+    title="Fink/ZTF object API",
     description="REST API to access data from Fink",
 )
 

--- a/apps/routes/v1/lsst/resolver/api.py
+++ b/apps/routes/v1/lsst/resolver/api.py
@@ -1,0 +1,92 @@
+# Copyright 2025 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from flask import Response, request
+from flask_restx import Namespace, Resource, fields
+
+from apps.utils.utils import check_args
+from apps.utils.utils import send_tabular_data
+
+from apps.routes.v1.lsst.resolver.utils import resolve_name
+
+DESCRIPTION = "Resolve astronomical names to LSST IDs, and vice-versa"
+
+ns = Namespace(
+    "api/v1/resolver", DESCRIPTION
+)
+
+ARGS = ns.model(
+    "resolver",
+    {
+        "resolver": fields.String(
+            description="Resolver among: `simbad`, `tns`",
+            example="tns",
+            required=True,
+        ),
+        "name_or_id": fields.String(
+            description="Object name to resolve.", example="SN 2024abtt", required=True
+        ),
+        "reverse": fields.Boolean(
+            description="If True, resolve LSST diaObjectId instead. Default is False.",
+            example=False,
+            required=False,
+        ),
+        "nmax": fields.Integer(
+            description="Maximum number of match to return. Default is 10.",
+            example=10,
+            required=False,
+        ),
+        "output-format": fields.String(
+            description="Output format among json[default], csv, parquet, votable.",
+            example="json",
+            required=False,
+        ),
+    },
+)
+
+
+@ns.route("")
+@ns.doc(params={k: ARGS[k].description for k in ARGS})
+class Resolver(Resource):
+    def get(self):
+        """{}""".format(DESCRIPTION)
+        payload = request.args
+        if len(payload) > 0:
+            # POST from query URL
+            return self.post()
+        else:
+            return Response(ns.description, 200)
+
+    @ns.expect(ARGS, location="json", as_dict=True)
+    def post(self):
+        """{}""".format(DESCRIPTION)
+        # get payload from the query URL
+        payload = request.args
+
+        if payload is None or len(payload) == 0:
+            # if no payload, try the JSON blob
+            payload = request.json
+
+        rep = check_args(ARGS, payload)
+        if rep["status"] != "ok":
+            return Response(str(rep), 400)
+
+        out = resolve_name(payload)
+
+        # Error propagation
+        if isinstance(out, Response):
+            return out
+
+        output_format = payload.get("output-format", "json")
+        return send_tabular_data(out, output_format)

--- a/apps/routes/v1/lsst/resolver/api.py
+++ b/apps/routes/v1/lsst/resolver/api.py
@@ -28,12 +28,14 @@ ARGS = ns.model(
     "resolver",
     {
         "resolver": fields.String(
-            description="Resolver among: `simbad`, `tns`",
+            description="Resolver among: `simbad`, `ssodnet`, `tns`",
             example="tns",
             required=True,
         ),
         "name_or_id": fields.String(
-            description="Object name to resolve.", example="SN 2024abtt", required=True
+            description="Astronomical object name or ID (if reverse is True) to resolve.",
+            example="SN 2024abtt",
+            required=True,
         ),
         "reverse": fields.Boolean(
             description="If True, resolve LSST diaObjectId instead. Default is False.",

--- a/apps/routes/v1/lsst/resolver/api.py
+++ b/apps/routes/v1/lsst/resolver/api.py
@@ -22,9 +22,7 @@ from apps.routes.v1.lsst.resolver.utils import resolve_name
 
 DESCRIPTION = "Resolve astronomical names to LSST IDs, and vice-versa"
 
-ns = Namespace(
-    "api/v1/resolver", DESCRIPTION
-)
+ns = Namespace("api/v1/resolver", DESCRIPTION)
 
 ARGS = ns.model(
     "resolver",

--- a/apps/routes/v1/lsst/resolver/utils.py
+++ b/apps/routes/v1/lsst/resolver/utils.py
@@ -15,7 +15,6 @@
 import io
 import requests
 import pandas as pd
-# from numpy import unique as npunique
 
 from apps.utils.client import connect_to_hbase_table
 from apps.utils.decoding import hbase_to_dict

--- a/apps/routes/v1/lsst/resolver/utils.py
+++ b/apps/routes/v1/lsst/resolver/utils.py
@@ -1,0 +1,182 @@
+# Copyright 2025 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import io
+import requests
+import pandas as pd
+# from numpy import unique as npunique
+
+from apps.utils.client import connect_to_hbase_table
+from apps.utils.decoding import hbase_to_dict
+
+from line_profiler import profile
+
+
+@profile
+def resolve_name(payload: dict) -> pd.DataFrame:
+    """Extract data returned by HBase and format it in a Pandas dataframe
+
+    Data is from /api/v1/resolver
+
+    Parameters
+    ----------
+    payload: dict
+        See https://api.fink-portal.org
+
+    Return
+    ----------
+    out: pandas dataframe
+    """
+    resolver = payload["resolver"]
+    name = payload["name"]
+    if "nmax" in payload:
+        nmax = payload["nmax"]
+    else:
+        nmax = 10
+
+    reverse = False
+    if "reverse" in payload:
+        if payload["reverse"] is True:
+            reverse = True
+
+    if resolver == "tns":
+        client = connect_to_hbase_table("rubin.tns_resolver")
+        client.setLimit(nmax)
+        if name == "":
+            # return the full table
+            results = client.scan(
+                "",
+                "",
+                "*",
+                0,
+                False,
+                False,
+            )
+        elif reverse:
+            # Prefix search on second part of the key which is `fullname_internalname`
+            to_evaluate = f"key:key:_{name}:substring"
+            results = client.scan(
+                "",
+                to_evaluate,
+                "*",
+                0,
+                False,
+                False,
+            )
+        else:
+            # indices are case-insensitive
+            to_evaluate = f"key:key:{name.lower()}"
+            results = client.scan(
+                "",
+                to_evaluate,
+                "*",
+                0,
+                False,
+                False,
+            )
+
+        # Restore default limits
+        client.close()
+
+        pdf = pd.DataFrame.from_dict(hbase_to_dict(results), orient="index")
+    elif resolver == "simbad":
+        client = connect_to_hbase_table("rubin.diaObject")
+        if reverse:
+            to_evaluate = f"key:key:{name}"
+            client.setLimit(nmax)
+            results = client.scan(
+                "",
+                to_evaluate,
+                "r:diaObjectId,f:cdsxmatch,r:ra,r:dec",
+                0,
+                False,
+                False,
+            )
+            client.close()
+            pdf = pd.DataFrame.from_dict(hbase_to_dict(results), orient="index")
+        else:
+            r = requests.get(
+                f"http://cds.unistra.fr/cgi-bin/nph-sesame/-oxp/~S?{name}",
+            )
+
+            check = pd.read_xml(io.BytesIO(r.content))
+            if "Resolver" in check.columns:
+                pdf = pd.read_xml(io.BytesIO(r.content), xpath=".//Resolver")
+            else:
+                pdf = pd.DataFrame()
+
+    # FIXME: For SSO it is not clear what to do for Rubin.
+    #        For ZTF, we needed to resolve the bizarre ssnamenr field, but
+    #        here Rubin gives a valid designation. On the other hand,
+    #        we might want to resolve a ssObjectId to a SSO name.
+    #        So we need the reverse search, but not the direct one.
+    # elif resolver == "ssodnet":
+    #     if reverse:
+    #         # ZTF alerts -> ssnmanenr
+    #         client = connect_to_hbase_table("ztf")
+    #         to_evaluate = f"key:key:{name}"
+    #         client.setLimit(nmax)
+    #         results = client.scan(
+    #             "",
+    #             to_evaluate,
+    #             "i:objectId,i:ssnamenr",
+    #             0,
+    #             False,
+    #             False,
+    #         )
+    #         client.close()
+    #         pdf = pd.DataFrame.from_dict(hbase_to_dict(results), orient="index")
+
+    #         # ssnmanenr -> MPC name & number
+    #         if not pdf.empty:
+    #             client = connect_to_hbase_table("ztf.sso_resolver")
+    #             ssnamenrs = npunique(pdf["i:ssnamenr"].to_numpy())
+    #             results = {}
+    #             for ssnamenr in ssnamenrs:
+    #                 result = client.scan(
+    #                     "",
+    #                     f"i:ssnamenr:{ssnamenr}:exact",
+    #                     "i:number,i:name,i:ssnamenr",
+    #                     0,
+    #                     False,
+    #                     False,
+    #                 )
+    #                 results.update(result)
+    #             client.close()
+    #             pdf = pd.DataFrame.from_dict(hbase_to_dict(results), orient="index")
+    #     else:
+    #         # MPC -> ssnamenr
+    #         # keys follow the pattern <name>-<deduplication>
+    #         client = connect_to_hbase_table("ztf.sso_resolver")
+
+    #         if nmax == 1:
+    #             # Prefix with internal marker
+    #             to_evaluate = f"key:key:{name.lower()}-"
+    #         elif nmax > 1:
+    #             # This enables e.g. autocompletion tasks
+    #             client.setLimit(nmax)
+    #             to_evaluate = f"key:key:{name.lower()}"
+
+    #         results = client.scan(
+    #             "",
+    #             to_evaluate,
+    #             "i:ssnamenr,i:name,i:number",
+    #             0,
+    #             False,
+    #             False,
+    #         )
+    #         client.close()
+    #         pdf = pd.DataFrame.from_dict(hbase_to_dict(results), orient="index")
+
+    return pdf

--- a/apps/routes/v1/lsst/resolver/utils.py
+++ b/apps/routes/v1/lsst/resolver/utils.py
@@ -118,11 +118,6 @@ def resolve_name(payload: dict) -> pd.DataFrame:
             else:
                 pdf = pd.DataFrame()
 
-    # FIXME: For SSO it is not clear what to do for Rubin.
-    #        For ZTF, we needed to resolve the bizarre ssnamenr field, but
-    #        here Rubin gives a valid designation. On the other hand,
-    #        we might want to resolve a ssObjectId to a SSO name.
-    #        So we need the reverse search, but not the direct one.
     elif resolver == "ssodnet":
         if reverse:
             # ssObjectId -> packed_name

--- a/apps/routes/v1/lsst/resolver/utils.py
+++ b/apps/routes/v1/lsst/resolver/utils.py
@@ -76,7 +76,8 @@ def resolve_name(payload: dict) -> pd.DataFrame:
             )
         else:
             # indices are case-insensitive
-            to_evaluate = f"key:key:{name.lower()}"
+            # salt is last letter of the name
+            to_evaluate = f"key:key:{name.lower()[-1]}_{name.lower()}"
             results = client.scan(
                 "",
                 to_evaluate,

--- a/apps/routes/v1/lsst/resolver/utils.py
+++ b/apps/routes/v1/lsst/resolver/utils.py
@@ -150,7 +150,7 @@ def resolve_name(payload: dict) -> pd.DataFrame:
                 "{}/api/v1/sso".format(config["APIURL"]),
                 json={
                     "n_or_d": name,
-                    "columns": "r:mpcDesignation,r:ssObjectId",
+                    "columns": "r:mpcDesignation,r:ssObjectId,r:diaSourceId",
                 },
             )
             pdf = pd.read_json(io.BytesIO(r.content))

--- a/apps/routes/v1/lsst/resolver/utils.py
+++ b/apps/routes/v1/lsst/resolver/utils.py
@@ -39,7 +39,7 @@ def resolve_name(payload: dict) -> pd.DataFrame:
     out: pandas dataframe
     """
     resolver = payload["resolver"]
-    name = payload["name"]
+    name = payload["name_or_id"]
     if "nmax" in payload:
         nmax = payload["nmax"]
     else:


### PR DESCRIPTION
Closes #88 

This PR adds a new route to resolve astronomical object names into LSST IDs, and vice-versa. Similarly to ZTF, we resolve names from `SIMBAD` (using the sesame resolver), `TNS` (using the daily produced catalog), and `SSODNET` (using packed name as a proxy). 

Profiling and tests are missing.