### PR TITLE
[ZTF] Endpoint to bulk download SSO data

### DIFF
--- a/app_ztf.py
+++ b/app_ztf.py
@@ -39,6 +39,7 @@ from apps.routes.v1.ztf.ssocand.api import ns as ns_ssocand
 from apps.routes.v1.ztf.anomaly.api import ns as ns_anomaly
 from apps.routes.v1.ztf.ssoft.api import ns as ns_ssoft
 from apps.routes.v1.ztf.metadata.api import ns as ns_metadata
+from apps.routes.v1.ztf.ssobulk.api import ns as ns_ssobulk
 
 config = extract_configuration("config.yml")
 
@@ -99,6 +100,7 @@ api.add_namespace(ns_statistics)
 api.add_namespace(ns_anomaly)
 api.add_namespace(ns_ssoft)
 api.add_namespace(ns_metadata)
+api.add_namespace(ns_ssobulk)
 
 # Register blueprint
 app.register_blueprint(blueprint)

--- a/apps/routes/v1/ztf/ssobulk/api.py
+++ b/apps/routes/v1/ztf/ssobulk/api.py
@@ -1,0 +1,77 @@
+# Copyright 2026 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from flask import Response, request
+from flask_restx import Namespace, Resource, fields
+
+from pandas import DataFrame
+
+from apps.utils.utils import check_args
+from apps.utils.utils import send_tabular_data
+
+from apps.routes.v1.ztf.ssobulk.utils import get_lc
+
+ns = Namespace("api/v1/ssobulk", "Get all Fink/ZTF SSO lightcurves in once")
+
+ARGS = ns.model(
+    "ssobulk",
+    {
+        "output-format": fields.String(
+            description="Output format among json, csv, parquet[default], votable.",
+            example="parquet",
+            required=False,
+        ),
+    },
+)
+
+
+@ns.route("")
+@ns.doc(params={k: ARGS[k].description for k in ARGS})
+class Ssobulk(Resource):
+    def get(self):
+        """Get all Fink/ZTF SSO lightcurves in once"""
+        payload = request.args
+        if len(payload) > 0:
+            # POST from query URL
+            return self.post()
+        else:
+            return Response(ns.description, 200)
+
+    @ns.expect(ARGS, location="json", as_dict=True)
+    def post(self):
+        """Get all Fink/ZTF SSO lightcurves in once"""
+        # get payload from the query URL
+        payload = request.args
+
+        if payload is None or len(payload) == 0:
+            # if no payload, try the JSON blob
+            payload = request.json
+
+        rep = check_args(ARGS, payload)
+        if rep["status"] != "ok":
+            return Response(str(rep), 400)
+
+        out = get_lc(payload)
+
+        # Error propagation
+        if isinstance(out, Response):
+            return out
+
+        # Return a record
+        if isinstance(out, DataFrame):
+            output_format = payload.get("output-format", "json")
+            return send_tabular_data(out, output_format)
+
+        # return the full table as binary
+        return out

--- a/apps/routes/v1/ztf/ssobulk/utils.py
+++ b/apps/routes/v1/ztf/ssobulk/utils.py
@@ -41,7 +41,7 @@ def get_lc(payload: dict) -> pd.DataFrame:
     # Need to profile compared to pyarrow
     input_args = yaml.load(open("config.yml"), yaml.Loader)
     r = requests.get(
-        "{}/sso_ztf_lc_aggregated_with_ssoft_202601_with_residuals.parquet?op=OPEN&user.name={}&namenoderpcaddress={}".format(
+        "{}/sso_ztf_lc_aggregated_with_ssoft_202601_with_residuals_singlefile.parquet?op=OPEN&user.name={}&namenoderpcaddress={}".format(
             input_args["WEBHDFS"],
             input_args["USER"],
             input_args["NAMENODE"],

--- a/apps/routes/v1/ztf/ssobulk/utils.py
+++ b/apps/routes/v1/ztf/ssobulk/utils.py
@@ -1,0 +1,59 @@
+# Copyright 2026 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from flask import Response
+
+import io
+import yaml
+import requests
+
+import pandas as pd
+
+from line_profiler import profile
+
+
+@profile
+def get_lc(payload: dict) -> pd.DataFrame:
+    """Send the Fink Flat Table
+
+    Data is from /api/v1/ssobulk
+
+    Parameters
+    ----------
+    payload: dict
+        See https://api.ztf.fink-portal.org
+
+    Return
+    ----------
+    out: pandas dataframe
+    """
+    # Need to profile compared to pyarrow
+    input_args = yaml.load(open("config.yml"), yaml.Loader)
+    r = requests.get(
+        "{}/sso_ztf_lc_aggregated_with_ssoft_202601_with_residuals.parquet?op=OPEN&user.name={}&namenoderpcaddress={}".format(
+            input_args["WEBHDFS"],
+            input_args["USER"],
+            input_args["NAMENODE"],
+        ),
+    )
+
+    if payload.get("output-format", "parquet") != "parquet":
+        # Full table in other format than parquet (slow)
+        return pd.read_parquet(io.BytesIO(r.content))
+    else:
+        # Full table in parquet (fast)
+        # return the schema of the table
+        response = Response(io.BytesIO(r.content), 200)
+        response.headers.set("Content-Type", "application/parquet")
+        return response


### PR DESCRIPTION
This PR adds a new route for the ZTF API to download all SSO lightcurve in once.

```bash
curl -H "Content-Type: application/json" -X POST \
    -d '{"output-format":"parquet"}' \
    https://api.ztf.fink-portal.org/api/v1/ssobulk \
    -o sso_fink_ztf_lc.parquet
```

It will download a 2GB parquet file on disk. The `output-format`  You can choose CSV, JSON, etc. as well for the output if you prefer, but that will be a bigger file. Columns should be self-explanatory, except the column residuals which is the difference between lightcurve and the sHG1G2 model (Carry et al 2024). This file contains only the SSO that pass criteria for model fitting (at least 50 measurements, all bands). That's about 180k objects.

This PR is a result of the LSST SSSC Sprint 2026 at Queens University, Belfast.

Todo:
- [ ] update the file on HDFS
- [ ] Add schema (GET?)