### PR TITLE
[Rubin] Fix conesearch logic

### DIFF
--- a/apps/routes/v1/lsst/conesearch/api.py
+++ b/apps/routes/v1/lsst/conesearch/api.py
@@ -56,7 +56,7 @@ ARGS = ns.model(
             required=False,
         ),
         "kind": fields.String(
-            description="When filtering by time, you can choose to filter alerts that had their first emission within those dates (within), or that appeared during those dates irrespective of their first variation time (across). Default is `within`",
+            description="When filtering by time, you can choose to filter objects that had their first and last emission strictly within those dates (within), or objects that appeared during those dates irrespective of their first and last variation time (across). Default is `within` (stricter). See https://doc.lsst.fink-broker.org/services/api/conesearch/ for more information.",
             example="within",
             required=False,
         ),

--- a/apps/routes/v1/lsst/conesearch/test.py
+++ b/apps/routes/v1/lsst/conesearch/test.py
@@ -131,14 +131,77 @@ def test_conesearch_with_dates_within() -> None:
         startdate="2026-01-07 10:00:00", window="2", radius=10.0, kind="within"
     )
 
+    # Filtering by end
+    pdf5 = conesearch(
+        stopdate="2026-01-09 10:00:00",
+        radius=10.0,
+        kind="within",
+    )
+
     # object(s) found
     assert len(pdf1) == 2, len(pdf1)
     assert len(pdf2) == 1, len(pdf2)
     assert len(pdf3) == 1, len(pdf3)
     assert len(pdf4) == 1, len(pdf4)
+    assert len(pdf5) == 1, len(pdf5)
     assert not pdf2.equals(pdf3)
     assert pdf3.equals(pdf4)
     assert pdf2.equals(pdf2b)
+
+
+def test_conesearch_with_dates_across() -> None:
+    """
+    Examples
+    --------
+    >>> test_conesearch_with_dates_across()
+    """
+    # within 10'', two objects
+    pdf1 = conesearch(
+        radius=10.0,
+    )
+
+    # Filtering the date leaves one object
+    pdf2 = conesearch(
+        startdate="2026-01-17 10:00:00",
+        radius=10.0,
+        kind="across",
+    )
+
+    # Check kind=within is the default
+    pdf2b = conesearch(
+        startdate="2026-01-17 10:00:00",
+        radius=10.0,
+    )
+
+    # Filtering both ends
+    pdf3 = conesearch(
+        startdate="2026-01-07 10:00:00",
+        stopdate="2026-01-17 10:00:00",
+        radius=10.0,
+        kind="across",
+    )
+
+    # same with window
+    pdf4 = conesearch(
+        startdate="2026-01-07 10:00:00", window="10", radius=10.0, kind="across"
+    )
+
+    # Filtering by end
+    pdf5 = conesearch(
+        stopdate="2026-01-09 10:00:00",
+        radius=10.0,
+        kind="across",
+    )
+
+    # object(s) found
+    assert len(pdf1) == 2, len(pdf1)
+    assert len(pdf2) == 1, len(pdf2)
+    assert len(pdf3) == 2, len(pdf3)
+    assert len(pdf4) == 2, len(pdf4)
+    assert len(pdf5) == 1, len(pdf5)
+    assert not pdf2.equals(pdf3)
+    assert pdf3.equals(pdf4)
+    assert not pdf2.equals(pdf2b)
 
 
 def test_bad_radius_conesearch() -> None:
@@ -199,6 +262,31 @@ def test_bad_dates() -> None:
     msg = {
         "status": "error",
         "text": "You need to specify f:firstDiaSourceMjdTaiFink in the columns to filter on dates.\n",
+    }
+    assert r.text == str(msg), r.text
+
+
+def test_bad_kind() -> None:
+    """
+    Examples
+    --------
+    >>> test_bad_kind()
+    """
+    payload = {
+        "ra": RA0,
+        "dec": DEC0,
+        "radius": 10,
+        "startdate": "2026-01-10 10:00:00",
+        "kind": "toto",
+        "columns": "r:diaObjectId,f:firstDiaSourceMjdTaiFink",
+        "output_format": "json",
+    }
+
+    r = requests.post(f"{APIURL}/api/v1/conesearch", json=payload)
+
+    msg = {
+        "status": "error",
+        "text": "kind must be one of: within, across. See https://doc.lsst.fink-broker.org/services/api/conesearch/ for more information.\n",
     }
     assert r.text == str(msg), r.text
 

--- a/apps/routes/v1/lsst/conesearch/test.py
+++ b/apps/routes/v1/lsst/conesearch/test.py
@@ -34,6 +34,7 @@ def conesearch(
     startdate=None,
     stopdate=None,
     window=None,
+    kind=None,
     columns=None,
     output_format="json",
 ):
@@ -48,6 +49,8 @@ def conesearch(
         payload.update({"stopdate": stopdate})
     if columns is not None:
         payload.update({"columns": columns})
+    if kind is not None:
+        payload.update({"kind": kind})
 
     r = requests.post(f"{APIURL}/api/v1/conesearch", json=payload)
 
@@ -91,11 +94,11 @@ def test_simple_conesearch() -> None:
     assert sep <= radius, sep
 
 
-def test_conesearch_with_dates() -> None:
+def test_conesearch_with_dates_within() -> None:
     """
     Examples
     --------
-    >>> test_conesearch_with_dates()
+    >>> test_conesearch_with_dates_within()
     """
     # within 10'', two objects
     pdf1 = conesearch(
@@ -106,20 +109,26 @@ def test_conesearch_with_dates() -> None:
     pdf2 = conesearch(
         startdate="2026-01-10 10:00:00",
         radius=10.0,
+        kind="within",
+    )
+
+    # Check kind is the default
+    pdf2b = conesearch(
+        startdate="2026-01-10 10:00:00",
+        radius=10.0,
     )
 
     # Filtering both ends
     pdf3 = conesearch(
         startdate="2026-01-07 10:00:00",
-        window="2",
+        stopdate="2026-01-09 10:00:00",
         radius=10.0,
+        kind="within",
     )
 
     # same with window
     pdf4 = conesearch(
-        startdate="2026-01-07 10:00:00",
-        stopdate="2026-01-09 10:00:00",
-        radius=10.0,
+        startdate="2026-01-07 10:00:00", window="2", radius=10.0, kind="within"
     )
 
     # object(s) found
@@ -129,6 +138,7 @@ def test_conesearch_with_dates() -> None:
     assert len(pdf4) == 1, len(pdf4)
     assert not pdf2.equals(pdf3)
     assert pdf3.equals(pdf4)
+    assert pdf2.equals(pdf2b)
 
 
 def test_bad_radius_conesearch() -> None:

--- a/apps/routes/v1/lsst/conesearch/utils.py
+++ b/apps/routes/v1/lsst/conesearch/utils.py
@@ -148,7 +148,11 @@ def run_conesearch(payload: dict) -> pd.DataFrame:
         return Response(str(rep), 400)
 
     # Filter by time
-    if ("startdate" in payload) and ("stopdate" not in payload):
+    if (
+        ("startdate" in payload)
+        and ("stopdate" not in payload)
+        and ("window" not in payload)
+    ):
         # startdate only
         startdate = Time(isoify_time(payload["startdate"]), scale="tai").tai.mjd
         if kind == "within":

--- a/apps/routes/v1/lsst/conesearch/utils.py
+++ b/apps/routes/v1/lsst/conesearch/utils.py
@@ -167,6 +167,7 @@ def run_conesearch(payload: dict) -> pd.DataFrame:
         elif kind == "across":
             # first point before stopdate
             cond = pdf["f:firstDiaSourceMjdTaiFink"] <= stopdate
+        pdf = pdf[cond]
     elif ("startdate" in payload) and (
         ("stopdate" in payload) or ("window" in payload)
     ):

--- a/apps/routes/v1/lsst/conesearch/utils.py
+++ b/apps/routes/v1/lsst/conesearch/utils.py
@@ -138,23 +138,59 @@ def run_conesearch(payload: dict) -> pd.DataFrame:
     if pdf.empty:
         return pdf
 
+    # Default filter by time is `within`
+    kind = payload.get("kind", "within")
+    if kind not in ["within", "across"]:
+        rep = {
+            "status": "error",
+            "text": "kind must be one of: within, across. See https://doc.lsst.fink-broker.org/services/api/conesearch/ for more information.\n",
+        }
+        return Response(str(rep), 400)
+
     # Filter by time
-    # FIXME: does not work yet as firstDiaSourceMjdTai is not populated
-    if "startdate" in payload:
-        # Filter out alerts that vary in the past
-        mjd_start = Time(isoify_time(payload["startdate"]), scale="tai").mjd
-        pdf = pdf[pdf["f:firstDiaSourceMjdTaiFink"] >= mjd_start]
-
+    if ("startdate" in payload) and ("stopdate" not in payload):
+        # startdate only
+        startdate = Time(isoify_time(payload["startdate"]), scale="tai").tai.mjd
+        if kind == "within":
+            # first point after startdate
+            cond = pdf["f:firstDiaSourceMjdTaiFink"] >= startdate
+        elif kind == "across":
+            # last point after startdate
+            cond = pdf["r:midpointMjdTai"] >= startdate
+        pdf = pdf[cond]
+    elif ("startdate" not in payload) and ("stopdate" in payload):
+        # stopdate only
+        stopdate = Time(isoify_time(payload["stopdate"]), scale="tai").tai.mjd
+        if kind == "within":
+            # last point before stopdate
+            cond = pdf["r:midpointMjdTai"] <= stopdate
+        elif kind == "across":
+            # first point before stopdate
+            cond = pdf["f:firstDiaSourceMjdTaiFink"] <= stopdate
+    elif ("startdate" in payload) and (
+        ("stopdate" in payload) or ("window" in payload)
+    ):
+        # both boundaries
+        startdate = Time(isoify_time(payload["startdate"]), scale="tai").tai.mjd
         if "window" in payload:
-            # Also filter out alerts that vary in the future
-            window = float(payload["window"])
-            mjd_stop = mjd_start + window
-            pdf = pdf[pdf["r:midpointMjdTai"] <= mjd_stop]
+            stopdate = startdate + float(payload["window"])
+        else:
+            stopdate = Time(isoify_time(payload["stopdate"]), scale="tai").tai.mjd
 
-    if "stopdate" in payload:
-        # Filter out alerts that vary in the future
-        mjd_stop = Time(isoify_time(payload["stopdate"]), scale="tai").mjd
-        pdf = pdf[pdf["r:midpointMjdTai"] <= mjd_stop]
+        if kind == "within":
+            # Completely contained
+            c0 = pdf["f:firstDiaSourceMjdTaiFink"] >= startdate
+            c1 = pdf["r:midpointMjdTai"] <= stopdate
+            cond = c0 * c1
+        elif kind == "across":
+            c0 = pdf["f:firstDiaSourceMjdTaiFink"] <= startdate
+            c1 = pdf["r:midpointMjdTai"] >= startdate
+            c2 = pdf["f:firstDiaSourceMjdTaiFink"] >= startdate
+            c3 = pdf["f:firstDiaSourceMjdTaiFink"] <= stopdate
+            # Started before startdate and ended after startdate OR
+            # Started in between startdate and stopdate
+            cond = (c0 & c1) | (c2 & c3)
+        pdf = pdf[cond]
 
     # For conesearch, sort by distance
     if len(pdf) > 0:


### PR DESCRIPTION
Closes #162

The conesearch logic regarding time filtering was confusing. In this PR we made it clearer.

Online documentation has been updated: https://doc.lsst.fink-broker.org/services/api/conesearch/

## What changed on the UI interface?

The parameter `kind` is now working properly. `kind=within` means one wants transients that strictly vary within the bounds. `kind=across` means all transients that had varied inside the bounds (but could also vary before/after). All other parameters remain the same. See below for graphical explanations that would hopefully drive the writing of the query.

## Filtering by boundaries

If the user specifies both `startdate` and `stopdate` (or `window`), depending on `kind`, here is what the user should expect (green=the object is returned, red=the object is not returned):

<img width="1085" height="677" alt="image" src="https://github.com/user-attachments/assets/2ddfe532-1876-44fc-ba44-4f1dfa81724a" />

## Filtering by startdate

If the user specifies `startdate`, depending on `kind`, here is what the user should expect (green=the object is returned, red=the object is not returned):

<img width="1085" height="677" alt="image" src="https://github.com/user-attachments/assets/6d3060b8-0971-4ef0-ba17-a61f7928cb2e" />

## Filtering by stopdate

If the user specifies `stopdate`, depending on `kind`, here is what the user should expect (green=the object is returned, red=the object is not returned):

<img width="1085" height="677" alt="image" src="https://github.com/user-attachments/assets/8873c275-7db7-4673-a2f8-d20bf5c5491b" />

